### PR TITLE
Check to see if the primary key is a string, if so, pass the string in sql call

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -90,8 +90,16 @@ class OverlapValidator < ActiveModel::EachValidator
     record.class.primary_key
   end
 
-  def primary_key_value(primary_key_name,record)
+  def primary_key_value(primary_key_name, record)
     record.send(primary_key_name)
+  end
+
+  def primary_key_type(record)
+    column_type(record.class,record.class.primary_key).to_sym
+  end
+
+  def column_type(model, name)
+   model.columns.detect { |c| c.name == name.to_s }.try(:type)
   end
 
   # Generate sql condition for time range cross
@@ -103,7 +111,7 @@ class OverlapValidator < ActiveModel::EachValidator
     if record.new_record?
       self.sql_conditions = main_condition
     else
-      if key.is_a?String
+      if primary_key_type(record) == :string
         self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != '#{key}'"
       else
         self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != #{key}"

--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -99,13 +99,14 @@ class OverlapValidator < ActiveModel::EachValidator
     starts_at_attr, ends_at_attr = attributes_to_sql(record)
     main_condition = condition_string(starts_at_attr, ends_at_attr)
     primary_key_name = primary_key(record)
+    key = primary_key_value(primary_key_name, record)
     if record.new_record?
       self.sql_conditions = main_condition
     else
-      if primary_key_value(primary_key_name, record).is_a?String
-        self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != '#{primary_key_value(primary_key_name, record)}'"
+      if key.is_a?String
+        self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != '#{key}'"
       else
-        self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != #{primary_key_value(primary_key_name, record)}"
+        self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != #{key}"
       end
     end
   end

--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -90,6 +90,10 @@ class OverlapValidator < ActiveModel::EachValidator
     record.class.primary_key
   end
 
+  def primary_key_value(primary_key_name,record)
+    record.send(primary_key_name)
+  end
+
   # Generate sql condition for time range cross
   def generate_overlap_sql_conditions(record)
     starts_at_attr, ends_at_attr = attributes_to_sql(record)
@@ -98,10 +102,13 @@ class OverlapValidator < ActiveModel::EachValidator
     if record.new_record?
       self.sql_conditions = main_condition
     else
-      self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key_name} != #{record.send(primary_key_name)}"
+      if primary_key_value(primary_key_name, record).is_a?String
+        self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != '#{primary_key_value(primary_key_name, record)}'"
+      else
+        self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} != #{primary_key_value(primary_key_name, record)}"
+      end
     end
   end
-
 
   # Return hash of values for overlap sql condition
   def generate_overlap_sql_values(record)

--- a/spec/dummy/app/models/secure_meeting.rb
+++ b/spec/dummy/app/models/secure_meeting.rb
@@ -1,0 +1,3 @@
+class SecureMeeting < ActiveRecord::Base
+  validates :starts_at, :ends_at, :overlap => true
+end

--- a/spec/dummy/db/migrate/20150707155107_create_secure_meetings.rb
+++ b/spec/dummy/db/migrate/20150707155107_create_secure_meetings.rb
@@ -1,0 +1,11 @@
+class CreateSecureMeetings < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+
+    create_table :secure_meetings, id: :uuid do |t|
+      t.date :starts_at
+      t.date :ends_at
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/spec/factories/secure_meeting.rb
+++ b/spec/dummy/spec/factories/secure_meeting.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :secure_meeting do |u|
+    u.starts_at '2010-11-05'.to_date
+    u.ends_at '2010-11-08'.to_date
+  end
+end

--- a/spec/dummy/spec/models/secure_meeting_spec.rb
+++ b/spec/dummy/spec/models/secure_meeting_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec/factories/secure_meeting'
+
+describe SecureMeeting  do
+  context "A model with a UUID as a primary key" do
+    before(:all) do
+    SecureMeeting.delete_all
+    end
+
+    it "updates the relevant record" do
+      meeting_uuid = FactoryGirl.create(:secure_meeting)
+      meeting_uuid.update(starts_at: '2012-01-05'.to_date, ends_at: '2012-02-05'.to_date)
+
+      meeting_uuid.should be_valid # or .should_not be_valid
+      meeting_uuid.errors[:starts_at].should be_empty # or .should_not be_empty
+      meeting_uuid.errors[:ends_at].should be_empty
+    end
+  end
+end

--- a/spec/dummy/spec/models/secure_meeting_spec.rb
+++ b/spec/dummy/spec/models/secure_meeting_spec.rb
@@ -1,18 +1,17 @@
 require_relative '../../spec/factories/secure_meeting'
 
-  describe SecureMeeting  do
-    context "A model with a UUID as a primary key" do
-      before(:all) do
+describe SecureMeeting do
+  context "A model with a UUID as a primary key" do
+    before(:all) do
       SecureMeeting.delete_all
-      end
+    end
 
-      it "updates the relevant record" do
-        securemeeting = FactoryGirl.create(:secure_meeting)
-        securemeeting.update(starts_at: '2012-01-05'.to_date, ends_at: '2012-02-05'.to_date)
-        securemeeting.should be_valid
-        securemeeting.errors[:starts_at].should be_empty
-        securemeeting.errors[:ends_at].should be_empty
-      end
+    it "updates the relevant record" do
+      securemeeting = FactoryGirl.create(:secure_meeting)
+      securemeeting.update(starts_at: '2012-01-05'.to_date, ends_at: '2012-02-05'.to_date)
+      securemeeting.should be_valid
+      securemeeting.errors[:starts_at].should be_empty
+      securemeeting.errors[:ends_at].should be_empty
     end
   end
-
+end

--- a/spec/dummy/spec/models/secure_meeting_spec.rb
+++ b/spec/dummy/spec/models/secure_meeting_spec.rb
@@ -1,18 +1,18 @@
 require_relative '../../spec/factories/secure_meeting'
 
-describe SecureMeeting  do
-  context "A model with a UUID as a primary key" do
-    before(:all) do
-    SecureMeeting.delete_all
-    end
+  describe SecureMeeting  do
+    context "A model with a UUID as a primary key" do
+      before(:all) do
+      SecureMeeting.delete_all
+      end
 
-    it "updates the relevant record" do
-      meeting_uuid = FactoryGirl.create(:secure_meeting)
-      meeting_uuid.update(starts_at: '2012-01-05'.to_date, ends_at: '2012-02-05'.to_date)
-
-      meeting_uuid.should be_valid # or .should_not be_valid
-      meeting_uuid.errors[:starts_at].should be_empty # or .should_not be_empty
-      meeting_uuid.errors[:ends_at].should be_empty
+      it "updates the relevant record" do
+        securemeeting = FactoryGirl.create(:secure_meeting)
+        securemeeting.update(starts_at: '2012-01-05'.to_date, ends_at: '2012-02-05'.to_date)
+        securemeeting.should be_valid
+        securemeeting.errors[:starts_at].should be_empty
+        securemeeting.errors[:ends_at].should be_empty
+      end
     end
   end
-end
+

--- a/spec/dummy/spec/overlap_validator_spec.rb
+++ b/spec/dummy/spec/overlap_validator_spec.rb
@@ -1,3 +1,4 @@
+require_relative '../spec/factories/secure_meeting'
 describe OverlapValidator do
 
 
@@ -19,6 +20,5 @@ describe OverlapValidator do
       subject.validate(meeting)
       meeting.errors[:optional_key].should eq ["Message content"]
     end
-
   end
 end

--- a/spec/dummy/spec/overlap_validator_spec.rb
+++ b/spec/dummy/spec/overlap_validator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec/factories/secure_meeting'
 describe OverlapValidator do
 
 
@@ -20,5 +19,6 @@ describe OverlapValidator do
       subject.validate(meeting)
       meeting.errors[:optional_key].should eq ["Message content"]
     end
+
   end
 end


### PR DESCRIPTION
In our application certain primary_keys are stored in the form of UUIDs. Unlike regular IDs UUIDs are  strings.

Unfortunately this is not yet supported while updating a record. Currently "....!= #{record.send(primary_key_name)}" inserts the primary key value stripping it of quotation marks. 

This PR checks to see if the primary key should be a string. If so it inserts them. 
